### PR TITLE
Fix guarded param protocol creation with parameters map

### DIFF
--- a/ametiste-routine-sdk/src/main/java/org/ametiste/routine/sdk/protocol/operation/AbstractParamProtocol.java
+++ b/ametiste-routine-sdk/src/main/java/org/ametiste/routine/sdk/protocol/operation/AbstractParamProtocol.java
@@ -17,10 +17,6 @@ public abstract class AbstractParamProtocol implements ParamsProtocol {
         this.paramsMap = new HashMap<>();
     }
 
-    protected AbstractParamProtocol(Map<String, String> params) {
-        fromMap(params);
-    }
-
     @Override
     public void fromMap(final Map<String, String> params) {
         paramsMap = Collections.unmodifiableMap(params);

--- a/ametiste-routine-sdk/src/main/java/org/ametiste/routine/sdk/protocol/operation/GuardedParamProtocol.java
+++ b/ametiste-routine-sdk/src/main/java/org/ametiste/routine/sdk/protocol/operation/GuardedParamProtocol.java
@@ -17,8 +17,9 @@ abstract public class GuardedParamProtocol extends AbstractParamProtocol {
     }
 
     protected GuardedParamProtocol(List<String> definedParams, Map<String, String> params) {
-        super(params);
+        super();
         this.definedParams = definedParams;
+        fromMap(params);
     }
 
     @Override


### PR DESCRIPTION
The problem occurs when we construct `GuardedParamProtocol` with prepared set of `params`:

```java
protected GuardedParamProtocol(List<String> definedParams, Map<String, String> params) {
    super(params);
    this.definedParams = definedParams;
}
```

Constructor of super class (`AbstractParamProtocol`) uses `fromMap` method to fill parameters map. This method is overridden by `GuardedParamProtocol` and inside provides check that passed params present in `definedParams`, but `definedParams` not defined yet and it causes NPE.