### PR TITLE
Renew backlog by cron

### DIFF
--- a/ametiste-routine-mod-backlog/src/main/java/org/ametiste/routine/mod/backlog/application/action/BacklogRenewAction.java
+++ b/ametiste-routine-mod-backlog/src/main/java/org/ametiste/routine/mod/backlog/application/action/BacklogRenewAction.java
@@ -4,7 +4,6 @@ import org.ametiste.routine.mod.backlog.application.service.BacklogRenewService;
 import org.ametiste.routine.mod.backlog.domain.BacklogRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  *
@@ -24,7 +23,6 @@ public class BacklogRenewAction {
     }
 
     // TODO: I need to externalize scheduling and make it framework agnostic. if possible
-    @Scheduled(fixedRateString = "${org.ametiste.routine.mod.backlog.renewRate:60000}")
     public void renewAll() {
         backlogRepository.loadAll().forEach(backlogRenewService::renewBy);
     }

--- a/ametiste-routine-mod-backlog/src/main/java/org/ametiste/routine/mod/backlog/configuration/BacklogModConfiguration.java
+++ b/ametiste-routine-mod-backlog/src/main/java/org/ametiste/routine/mod/backlog/configuration/BacklogModConfiguration.java
@@ -99,7 +99,7 @@ public class BacklogModConfiguration {
         @Autowired
         private BacklogRenewAction backlogRenewAction;
 
-        @Scheduled(fixedDelayString = "${org.ametiste.routine.mod.backlog.renewRate:60000}")
+        @Scheduled(fixedRateString = "${org.ametiste.routine.mod.backlog.renewRate:60000}")
         private void renew() {
             backlogRenewAction.renewAll();
         }

--- a/ametiste-routine-mod-backlog/src/main/java/org/ametiste/routine/mod/backlog/configuration/BacklogModConfiguration.java
+++ b/ametiste-routine-mod-backlog/src/main/java/org/ametiste/routine/mod/backlog/configuration/BacklogModConfiguration.java
@@ -9,7 +9,10 @@ import org.ametiste.routine.mod.backlog.application.service.BacklogRenewConstrai
 import org.ametiste.routine.mod.backlog.application.service.BacklogRenewService;
 import org.ametiste.routine.mod.backlog.domain.Backlog;
 import org.ametiste.routine.mod.backlog.domain.BacklogRepository;
-import org.ametiste.routine.mod.backlog.infrastructure.*;
+import org.ametiste.routine.mod.backlog.infrastructure.BacklogPopulationStrategiesRegistry;
+import org.ametiste.routine.mod.backlog.infrastructure.BacklogPopulationStrategy;
+import org.ametiste.routine.mod.backlog.infrastructure.MemoryBacklogPopulationStrategiesRegistry;
+import org.ametiste.routine.mod.backlog.infrastructure.MemoryBacklogRepository;
 import org.ametiste.routine.mod.backlog.mod.ModBacklog;
 import org.ametiste.routine.mod.tasklog.domain.TaskLogRepository;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +21,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
 
 import java.util.Collections;
 import java.util.List;
@@ -88,4 +92,29 @@ public class BacklogModConfiguration {
         return new ActiveBacklogTasksConstraint(taskLogRepository);
     }
 
+    @Configuration
+    @ConditionalOnProperty(name = "org.ametiste.routine.mod.backlog.useCron", havingValue = "false", matchIfMissing = true)
+    static class FixedRateRenewConfiguration {
+
+        @Autowired
+        private BacklogRenewAction backlogRenewAction;
+
+        @Scheduled(fixedDelayString = "${org.ametiste.routine.mod.backlog.renewRate:60000}")
+        private void renew() {
+            backlogRenewAction.renewAll();
+        }
+    }
+
+    @Configuration
+    @ConditionalOnProperty(name = "org.ametiste.routine.mod.backlog.useCron", havingValue = "true")
+    static class CronRenewConfiguration {
+
+        @Autowired
+        private BacklogRenewAction backlogRenewAction;
+
+        @Scheduled(cron = "${org.ametiste.routine.mod.backlog.renewCron:0 * * * * *}")
+        private void renew() {
+            backlogRenewAction.renewAll();
+        }
+    }
 }


### PR DESCRIPTION
In some cases we need to issue tasks by fixed schedule that doesn't depend on service start time. To provide this ability was added additional scheduling configuration with cron parameter.

**New properties:**
Common prefix: `org.ametiste.routine.mod.backlog.*`

Name|Type|Description|Default
-------|:------:|------------|:--------:
`useCron`|`boolean`|Enables cron renew configuration.|`false`
`renewCron`|`string`|Cron configuration string.|`0 * * * * *`

By default used _FixedRate_ renew configuration that provides compatibility with code written with previous versions.